### PR TITLE
Fix SQLSTATE[42000] Error while executing migrations & Routes Refactoring

### DIFF
--- a/app/Providers/RouteServiceProvider.php
+++ b/app/Providers/RouteServiceProvider.php
@@ -46,6 +46,12 @@ class RouteServiceProvider extends ServiceProvider
             Route::middleware('web')
                 ->namespace($this->namespace)
                 ->group(base_path('routes/web.php'));
+
+	        Route::middleware(['web', 'isAdmin'])
+		        ->namespace($this->namespace)
+		        ->prefix('admin/')
+		        ->as('admin.')
+		        ->group(base_path('routes/admin.php'));
         });
     }
 

--- a/database/migrations/2021_02_11_143955_add_books_description.php
+++ b/database/migrations/2021_02_11_143955_add_books_description.php
@@ -14,7 +14,7 @@ class AddBooksDescription extends Migration
     public function up()
     {
         Schema::table('books', function (Blueprint $table) {
-            $table->text('description')->after('slug')->default('');
+            $table->text('description')->after('slug')->nullable();
         });
     }
 

--- a/routes/admin.php
+++ b/routes/admin.php
@@ -1,0 +1,27 @@
+<?php
+
+use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\Admin\AdminBookController;
+use App\Http\Controllers\Admin\AdminUsersController;
+use App\Http\Controllers\Admin\AdminDashboardController;
+
+Route::get('',AdminDashboardController::class)->name('index');
+
+//==========*** User ***===========
+Route::prefix('users/')->name('users.')->group(function() {
+	Route::get(   '',                  [AdminUsersController::class, 'index'            ])->name('index');
+	Route::get(   '{user}/edit',       [AdminUsersController::class, 'edit'             ])->name('edit');
+	Route::put(   '{user}',            [AdminUsersController::class, 'update'           ])->name('update');
+	Route::delete('{user}',            [AdminUsersController::class, 'destroy'          ])->name('destroy');
+});
+
+//==========*** Book ***===========
+Route::prefix('books/')->name('books.')->group(function() {
+	Route::get(   '',                  [AdminBookController::class, 'index'             ])->name('index');
+	Route::post(  '',                  [AdminBookController::class, 'store'             ])->name('store');
+	Route::get(   'create',            [AdminBookController::class, 'create'            ])->name('create');
+	Route::get(   '{book}/edit',       [AdminBookController::class, 'edit'              ])->name('edit');
+	Route::put(   '{book}',            [AdminBookController::class, 'update'            ])->name('update');
+	Route::delete('{book}',            [AdminBookController::class, 'destroy'           ])->name('destroy');
+	Route::put(   'approve/{book}',    [AdminBookController::class, 'approveBook'       ])->name('approve');
+});

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,49 +1,51 @@
 <?php
 
 use Illuminate\Support\Facades\Route;
+use App\Http\Controllers\BookController;
+use App\Http\Controllers\OrderController;
+use App\Http\Controllers\UserChangePassword;
+use App\Http\Controllers\BookReportController;
+use App\Http\Controllers\UserSettingsController;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
+/**=================================//
+//******** Auth Routes **********
+ ** ================================ */
+Route::middleware('auth')->group(function () {
 
-Route::get('/', \App\Http\Controllers\HomeController::class)->name('home');
-Route::get('book/create', [\App\Http\Controllers\BookController::class, 'create'])->middleware('auth')->name('books.create');
-Route::post('book/store', [\App\Http\Controllers\BookController::class, 'store'])->middleware('auth')->name('books.store');
-Route::get('book/{book:slug}/report/create', [\App\Http\Controllers\BookReportController::class, 'create'])->middleware('auth')->name('books.report.create');
-Route::post('book/{book}/report', [\App\Http\Controllers\BookReportController::class, 'store'])->middleware('auth')->name('books.report.store');
-Route::get('book/{book:slug}', [\App\Http\Controllers\BookController::class, 'show'])->name('books.show');
+	//==========*** User ***===========
+	Route::prefix('user/')->name('user.')->group(function () {
 
-Route::get('user/books', [\App\Http\Controllers\BookController::class, 'index'])->middleware('auth')->name('user.books.list');
-Route::get('user/books/{book:slug}/edit', [\App\Http\Controllers\BookController::class, 'edit'])->middleware('auth')->name('user.books.edit');
-Route::put('user/books/{book:slug}', [\App\Http\Controllers\BookController::class, 'update'])->middleware('auth')->name('user.books.update');
-Route::delete('user/books/{book}', [\App\Http\Controllers\BookController::class, 'destroy'])->middleware('auth')->name('user.books.destroy');
+		Route::get('orders', [OrderController::class, 'index'])->name('orders.index');
 
-Route::get('user/orders', [\App\Http\Controllers\OrderController::class, 'index'])->middleware('auth')->name('user.orders.index');
+		Route::prefix('books/')->name('books.')->group(function () {
+			Route::get(   '',                          [BookController::class, 'index'              ])->name('list');
+			Route::put(   '{book:slug}',               [BookController::class, 'update'             ])->name('update');
+			Route::get(   '{book:slug}/edit',          [BookController::class, 'edit'               ])->name('edit');
+			Route::delete('{book}',                    [BookController::class, 'destroy'            ])->name('destroy');
+		});
 
-Route::get('user/settings', [\App\Http\Controllers\UserSettingsController::class, 'index'])->middleware('auth')->name('user.settings');
-Route::post('user/settings/{user}', [\App\Http\Controllers\UserSettingsController::class, 'update'])->middleware('auth')->name('user.settings.update');
-Route::post('user/settings/password/change/{user}', [\App\Http\Controllers\UserChangePassword::class, 'update'])->middleware('auth')->name('user.password.update');
+		Route::prefix('settings/')->group(function () {
+			Route::get( '',                            [UserSettingsController::class, 'index'      ])->name('settings');
+			Route::post('{user}',                      [UserSettingsController::class, 'update'     ])->name('settings.update');
+			Route::post('password/change/{user}',      [UserChangePassword::class, 'update'         ])->name('password.update');
+		});
 
-Route::get('admin', \App\Http\Controllers\Admin\AdminDashboardController::class)->middleware('isAdmin')->name('admin.index');
+	});
 
-Route::get('admin/books', [\App\Http\Controllers\Admin\AdminBookController::class, 'index'])->middleware('isAdmin')->name('admin.books.index');
-Route::get('admin/books/create', [\App\Http\Controllers\Admin\AdminBookController::class, 'create'])->middleware('isAdmin')->name('admin.books.create');
-Route::post('admin/books', [\App\Http\Controllers\Admin\AdminBookController::class, 'store'])->middleware('isAdmin')->name('admin.books.store');
-Route::get('admin/books/{book}/edit', [\App\Http\Controllers\Admin\AdminBookController::class, 'edit'])->middleware('isAdmin')->name('admin.books.edit');
-Route::put('admin/books/{book}', [\App\Http\Controllers\Admin\AdminBookController::class, 'update'])->middleware('isAdmin')->name('admin.books.update');
-Route::delete('admin/books/{book}', [\App\Http\Controllers\Admin\AdminBookController::class, 'destroy'])->middleware('isAdmin')->name('admin.books.destroy');
-Route::put('admin/book/approve/{book}', [\App\Http\Controllers\Admin\AdminBookController::class, 'approveBook'])->middleware('isAdmin')->name('admin.books.approve');
+	//==========*** Book ***===========
+	Route::prefix('book/')->name('books.')->group(function () {
+		Route::get( 'create',                       [BookController::class, 'create'            ])->name('create');
+		Route::post('store',                        [BookController::class, 'store'             ])->name('store');
+		Route::post('{book}/report',                [BookReportController::class, 'store'       ])->name('report.store');
+		Route::get( '{book:slug}/report/create',    [BookReportController::class, 'create'      ])->name('report.create');
+	});
 
-Route::get('admin/users', [\App\Http\Controllers\Admin\AdminUsersController::class, 'index'])->middleware('isAdmin')->name('admin.users.index');
-Route::get('admin/users/{user}/edit', [\App\Http\Controllers\Admin\AdminUsersController::class, 'edit'])->middleware('isAdmin')->name('admin.users.edit');
-Route::put('admin/users/{user}', [\App\Http\Controllers\Admin\AdminUsersController::class, 'update'])->middleware('isAdmin')->name('admin.users.update');
-Route::delete('admin/users/{user}', [\App\Http\Controllers\Admin\AdminUsersController::class, 'destroy'])->middleware('isAdmin')->name('admin.users.destroy');
+});
+
+/**=================================//
+//******** Public Routes **********
+ ** ================================ */
+Route::view('/', 'front.home')->name('home');
+Route::get('book/{book:slug}', [BookController::class, 'show'])->name('books.show');
 
 require __DIR__ . '/auth.php';


### PR DESCRIPTION
![Annotation 2021-09-02 192320](https://user-images.githubusercontent.com/32367934/131869354-014d3997-22b3-444d-9344-7320255a5c9b.jpg)

Face  SQLSTATE[42000] error while executing migrations. So I just replaced:

`$table->text('description')->after('slug')->default('');`

with:

`$table->text('description')->after('slug')->nullable();`

in `2021_02_11_143955_add_books_description` file which I think is more accurate way and the problem is gone.